### PR TITLE
Updated enforcement section's contact info

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,9 +55,13 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at foss-responders@googlegroups.com or nsanchez@gitlab.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
+reported by contacting members of the project team: 
+
+ * Duane O'Brien and Richard Littauer at: foss-responders@googlegroups.com 
+ * Nuritzi Sanchez at: nuritzis@gmail.com
+
+All complaints will be reviewed and investigated and will result in a response 
+that is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 


### PR DESCRIPTION
Changed my email address and also listed Richard and Duane's names so that people know who is at the other end of that google group. May want to consider adding personal emails instead.

@RichardLitt please merge if it looks ok to you. I added some formatting changes to make it easier for people to quickly see how to contact us. 